### PR TITLE
Task4/logging error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 node_modules
+logs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1120,6 +1120,16 @@
         "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
+    "@dabh/diagnostics": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.2.tgz",
+      "integrity": "sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==",
+      "requires": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -2174,6 +2184,11 @@
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.2.tgz",
+      "integrity": "sha512-H0E+qZaDEfx/FY4t7iLRv1W2fFI6+pyCeTw1uN20AQPiwqwM6ojPxHxdLv4z8hi2DtnW9BOckSspLucW7pIE5g=="
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2624,6 +2639,14 @@
             "kind-of": "^6.0.2"
           }
         }
+      }
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
       }
     },
     "binary-extensions": {
@@ -3147,6 +3170,15 @@
         "object-visit": "^1.0.0"
       }
     },
+    "color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "requires": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3160,11 +3192,34 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "color-string": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.0.tgz",
+      "integrity": "sha512-9Mrz2AQLefkH1UvASKj6v6hj/7eWgjnT/cVsR8CumieLoT+g900exWeNogqtweI8dxloXN9BDQTYro1oWu/5CQ==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "colorette": {
       "version": "2.0.16",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
       "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
       "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
+    },
+    "colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "requires": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
+      }
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3661,6 +3716,11 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -4411,6 +4471,11 @@
         }
       }
     },
+    "express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
+    },
     "extend-shallow": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
@@ -4558,6 +4623,11 @@
         "bser": "2.1.1"
       }
     },
+    "fecha": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.1.tgz",
+      "integrity": "sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q=="
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4633,6 +4703,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
+    },
+    "fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -5548,8 +5623,7 @@
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
     },
     "is-string": {
       "version": "1.0.7",
@@ -6367,6 +6441,11 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
@@ -6563,6 +6642,25 @@
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0"
           }
+        }
+      }
+    },
+    "logform": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.3.0.tgz",
+      "integrity": "sha512-graeoWUH2knKbGthMtuG1EfaSPMZFZBIrhuJHhkS5ZseFBrc7DupCzihOQAzsK/qIKPQaPJ/lFQFctILUY5ARQ==",
+      "requires": {
+        "colors": "^1.2.1",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^1.1.0",
+        "triple-beam": "^1.3.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
     },
@@ -6773,6 +6871,33 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "ms": {
@@ -7066,12 +7191,25 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
+      }
+    },
+    "one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "requires": {
+        "fn.name": "1.x.x"
       }
     },
     "onetime": {
@@ -7624,7 +7762,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7913,6 +8050,11 @@
       "requires": {
         "ret": "~0.1.10"
       }
+    },
+    "safe-stable-stringify": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-1.1.1.tgz",
+      "integrity": "sha512-ERq4hUjKDbJfE4+XtZLFPCDi8Vb1JqaxAPTxWFLBx8XcAlf9Bda/ZJdVezs/NAfsMQScyIlUMx+Yeu7P7rx5jw=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -8317,6 +8459,21 @@
       "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      },
+      "dependencies": {
+        "is-arrayish": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -8560,6 +8717,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -8666,7 +8828,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -8674,8 +8835,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -8887,6 +9047,11 @@
         "minimatch": "^3.0.4"
       }
     },
+    "text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9001,6 +9166,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "triple-beam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
+      "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "ts-node": {
       "version": "10.4.0",
@@ -9356,8 +9526,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -9506,6 +9675,32 @@
       "dev": true,
       "requires": {
         "string-width": "^4.0.0"
+      }
+    },
+    "winston": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.3.3.tgz",
+      "integrity": "sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==",
+      "requires": {
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.1.0",
+        "is-stream": "^2.0.0",
+        "logform": "^2.2.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.4.0"
+      }
+    },
+    "winston-transport": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.4.1.tgz",
+      "integrity": "sha512-ciZRlU4CSjHqHe8RQG1iPxKMRVwv6ZJ0RC7DxStKWd0KjpAhPDy5gVYSCpIUq+5CUsP+IyNOTZy1X0tO2QZqjg==",
+      "requires": {
+        "logform": "^2.2.0",
+        "readable-stream": "^3.4.0",
+        "triple-beam": "^1.2.0"
       }
     },
     "word-wrap": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.3.0",
     "express": "4.17.1",
+    "express-async-handler": "^1.2.0",
     "http-status-codes": "^2.1.4",
+    "morgan": "^1.10.0",
     "of": "^1.0.0",
     "path": "^0.12.7",
     "peer": "^0.6.1",
@@ -57,6 +59,7 @@
     "ts-node": "^10.4.0",
     "tsconfig": "^7.0.0",
     "uuid": "8.3.2",
+    "winston": "^3.3.3",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,11 +8,15 @@ import consumerRouter from "./resources/consumer/consumer.router";
 import orderRouter from "./resources/order/order.router";
 import productRouter from "./resources/product/product.router";
 
+import { logging } from './middlewares';
+
 const app = express();
 
 const swaggerDocument = YAML.load(path.join(__dirname, '../doc/api.yaml'));
 
 app.use(express.json());
+
+app.use(logging);
 
 app.use('/doc', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,15 +8,13 @@ import consumerRouter from "./resources/consumer/consumer.router";
 import orderRouter from "./resources/order/order.router";
 import productRouter from "./resources/product/product.router";
 
-import { logging } from './middlewares';
+import { logging, errorHandling } from './middlewares';
 
 const app = express();
 
 const swaggerDocument = YAML.load(path.join(__dirname, '../doc/api.yaml'));
 
 app.use(express.json());
-
-app.use(logging);
 
 app.use('/doc', swaggerUI.serve, swaggerUI.setup(swaggerDocument));
 
@@ -28,8 +26,10 @@ app.use('/', (req, res, next) => {
   next();
 });
 
+app.use(logging);
 app.use('/consumers', consumerRouter);
 app.use('/orders', orderRouter);
 app.use('/products', productRouter);
+app.use(errorHandling);
 
 export default app;

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,9 +27,11 @@ app.use('/', (req, res, next) => {
 });
 
 app.use(logging);
+
 app.use('/consumers', consumerRouter);
 app.use('/orders', orderRouter);
 app.use('/products', productRouter);
+
 app.use(errorHandling);
 
 export default app;

--- a/src/middlewares/errorHandling.ts
+++ b/src/middlewares/errorHandling.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import { Request, Response } from 'express';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import fs from 'fs';
 import path from 'path';
@@ -11,7 +11,6 @@ export const errorHandling = async (
     error: Error,
     _req: Request,
     res: Response,
-    _next: NextFunction,
 ) => {
     const { name, message, stack } = error;
     const statusCode = name === 'Error' ? StatusCodes.NOT_FOUND : StatusCodes.INTERNAL_SERVER_ERROR;

--- a/src/middlewares/errorHandling.ts
+++ b/src/middlewares/errorHandling.ts
@@ -16,6 +16,7 @@ export const errorHandling = async (
     const { name, message, stack } = error;
     const statusCode = name === 'Error' ? StatusCodes.NOT_FOUND : StatusCodes.INTERNAL_SERVER_ERROR;
     const logsFolder = path.join(__dirname, '../../logs');
+    const errorTime = new Date();
 
     if (!fs.existsSync(logsFolder)) {
         fs.mkdirSync(logsFolder);
@@ -24,6 +25,7 @@ export const errorHandling = async (
     try {
         await pipeline(
             stream.Readable.from(`
+      errorTime:       ${errorTime}
       status code:     ${statusCode}
       errorName:       ${name}
       errorMessage:    ${message}
@@ -38,6 +40,6 @@ export const errorHandling = async (
         process.exit(1);
     }
 
-    res.status(500).send('Internal server error');
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR);
     next();
 };

--- a/src/middlewares/errorHandling.ts
+++ b/src/middlewares/errorHandling.ts
@@ -1,0 +1,43 @@
+import { NextFunction, Request, Response } from 'express';
+import { StatusCodes, getReasonPhrase } from 'http-status-codes';
+import fs from 'fs';
+import path from 'path';
+import stream from 'stream';
+import util from 'util';
+
+const pipeline = util.promisify(stream.pipeline);
+
+export const errorHandling = async (
+    error: Error,
+    _req: Request,
+    res: Response,
+    _next: NextFunction,
+) => {
+    const { name, message, stack } = error;
+    const statusCode = name === 'Error' ? StatusCodes.NOT_FOUND : StatusCodes.INTERNAL_SERVER_ERROR;
+    const messageReason = getReasonPhrase(statusCode);
+    const logsFolder = path.join(__dirname, '../../logs');
+
+    if (!fs.existsSync(logsFolder)) {
+        fs.mkdirSync(logsFolder);
+    }
+
+    try {
+        await pipeline(
+            stream.Readable.from(`
+       status code:     ${statusCode}
+       errorName:       ${name}
+       errorMessage:    ${message}
+       errorStack:      ${stack}\n
+       `),
+            fs.createWriteStream(path.join(__dirname, '../../logs/errorHandling.txt'), {
+                flags: 'a',
+            }),
+        );
+    } catch (er) {
+        process.stderr.write(`${console.error(er)}`);
+        process.exit(1);
+    }
+
+    return res.status(statusCode).json({ statusCode, messageReason });
+};

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,5 +1,5 @@
 import { logging } from './logging';
-// import {uncaughtHandling} from './uncaughtHandling';
-// import {errorHandling} from './errorHandling';
+import { unhandledRejection, uncaughtException } from './uncaughtHandling';
+//import { errorHandling } from './errorHandling';
 
-export { logging }
+export { logging, unhandledRejection, uncaughtException, }

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,0 +1,5 @@
+import { logging } from './logging';
+// import {uncaughtHandling} from './uncaughtHandling';
+// import {errorHandling} from './errorHandling';
+
+export { logging }

--- a/src/middlewares/index.ts
+++ b/src/middlewares/index.ts
@@ -1,5 +1,5 @@
 import { logging } from './logging';
 import { unhandledRejection, uncaughtException } from './uncaughtHandling';
-//import { errorHandling } from './errorHandling';
+import { errorHandling } from './errorHandling';
 
-export { logging, unhandledRejection, uncaughtException, }
+export { logging, unhandledRejection, uncaughtException, errorHandling }

--- a/src/middlewares/logging.ts
+++ b/src/middlewares/logging.ts
@@ -26,8 +26,8 @@ export const logging = async (req: Request, res: Response, next: NextFunction) =
         request Time:     ${requestTime}
         method:           ${req.method}
         url:              ${`http://localhost:${PORT}${req.baseUrl + req.url}`}
-        body:             ${JSON.stringify(req.body)}
-        query:            ${JSON.stringify(req.query)}
+        body:             ${JSON.stringify(req.body, null, '\t')}
+        query:            ${JSON.stringify(req.query, null, '\t')}
         params:           ${JSON.stringify(req.params)}
         processing time:  ${processTime} ms
         status code:      ${res.statusCode}\n`),

--- a/src/middlewares/logging.ts
+++ b/src/middlewares/logging.ts
@@ -4,9 +4,9 @@ import path from 'path';
 import stream from 'stream';
 import util from 'util';
 
-const pipeline = util.promisify(stream.pipeline);
-
 import config from '../common/config';
+
+const pipeline = util.promisify(stream.pipeline);
 
 const { PORT } = config;
 

--- a/src/middlewares/logging.ts
+++ b/src/middlewares/logging.ts
@@ -1,0 +1,47 @@
+import { NextFunction, Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+import { pipeline } from 'stream';
+
+import config from '../common/config';
+
+const { PORT } = config;
+
+export const logging = async (req: Request, res: Response, next: NextFunction) => {
+    const requestTime = new Date();
+    const method = req.method;
+    const url = `http://localhost:${PORT}${req.baseUrl + req.url}`;
+    const body = JSON.stringify(req.body);
+    const query = JSON.stringify(req.query);
+    const params = JSON.stringify(req.params);
+    const statusCode = res.statusCode;
+    const processTime = Date.now() - + requestTime;
+
+    const logsFolder = path.join(__dirname, '../../logs');
+
+    if (!fs.existsSync(logsFolder)) {
+        fs.mkdirSync(logsFolder);
+    }
+
+    await pipeline(
+        `
+ Request:
+     request Time:     ${requestTime}
+     method:           ${method}
+     url:              ${url}
+     body:             ${body}
+     query:            ${query}
+     params:           ${params}
+     processing time:  ${processTime} ms
+ Response:
+     status code:      ${statusCode}\n`,
+        fs.createWriteStream(path.join(__dirname, '../../logs/logging.txt'), { flags: 'a' }),
+        (error) => {
+            if (error) {
+                process.stderr.write(error.message);
+                process.exit(1);
+            }
+        },
+    );
+    next();
+};

--- a/src/middlewares/logging.ts
+++ b/src/middlewares/logging.ts
@@ -10,7 +10,7 @@ const pipeline = util.promisify(stream.pipeline);
 
 const { PORT } = config;
 
-export const logging = async (error: Error, req: Request, res: Response, next: NextFunction) => {
+export const logging = async (req: Request, res: Response, next: NextFunction) => {
     const requestTime = new Date();
     const processTime = Date.now() - + requestTime;
 
@@ -34,7 +34,7 @@ export const logging = async (error: Error, req: Request, res: Response, next: N
             fs.createWriteStream(path.join(__dirname, '../../logs/logging.log'), { flags: 'a' }),
         );
     } catch (er) {
-        process.stderr.write(`${error.message}`);
+        process.stderr.write(`${console.error(er)}`);
         process.exit(1);
     }
     next();

--- a/src/middlewares/logging.ts
+++ b/src/middlewares/logging.ts
@@ -10,7 +10,7 @@ const pipeline = util.promisify(stream.pipeline);
 
 const { PORT } = config;
 
-export const logging = async (req: Request, res: Response, next: NextFunction) => {
+export const logging = async (error: Error, req: Request, res: Response, next: NextFunction) => {
     const requestTime = new Date();
     const processTime = Date.now() - + requestTime;
 
@@ -31,10 +31,10 @@ export const logging = async (req: Request, res: Response, next: NextFunction) =
         params:           ${JSON.stringify(req.params)}
         processing time:  ${processTime} ms
         status code:      ${res.statusCode}\n`),
-            fs.createWriteStream(path.join(__dirname, '../../logs/logging.txt'), { flags: 'a' }),
+            fs.createWriteStream(path.join(__dirname, '../../logs/logging.log'), { flags: 'a' }),
         );
     } catch (er) {
-        process.stderr.write(`${console.error(er)}`);
+        process.stderr.write(`${error.message}`);
         process.exit(1);
     }
     next();

--- a/src/middlewares/uncaughtHandling.ts
+++ b/src/middlewares/uncaughtHandling.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+export const uncaughtException = async (error: Error) => {
+    const { name, message } = error;
+    const logsFolder = path.join(__dirname, '../../logs');
+
+    if (!fs.existsSync(logsFolder)) {
+        fs.mkdirSync(logsFolder);
+    }
+
+    fs.appendFileSync(
+        path.join(__dirname, '../../logs/uncaughtExceptions.txt'),
+        `
+     time:            ${new Date()}
+     errorName:       ${name}
+     errorMessage:    ${message}\n`,
+    );
+    process.stderr.write(`uncaughtException: ${error.message} \n,${error.stack}`);
+    process.exit(1);
+};
+
+export const unhandledRejection = async (error: Error, promise: Promise<any>) => {
+    const { message } = error;
+    const logsFolder = path.join(__dirname, '../../logs');
+
+    if (!fs.existsSync(logsFolder)) {
+        fs.mkdirSync(logsFolder);
+    }
+
+    fs.appendFileSync(
+        path.join(__dirname, '../../logs/unhandledRejection.txt'),
+        `
+     time:                   ${new Date()}
+     unhandledRejection:     ${JSON.stringify(promise)}
+     errorMessage:           ${message}\n`,
+    );
+    process.stderr.write(`unhandledRejection: ${error.message} \n,${error.stack}`);
+    process.exit(1);
+};

--- a/src/middlewares/uncaughtHandling.ts
+++ b/src/middlewares/uncaughtHandling.ts
@@ -10,7 +10,7 @@ export const uncaughtException = async (error: Error) => {
     }
 
     fs.appendFileSync(
-        path.join(__dirname, '../../logs/uncaughtExceptions.txt'),
+        path.join(__dirname, '../../logs/uncaughtExceptions.log'),
         `
      time:            ${new Date()}
      errorName:       ${name}
@@ -29,7 +29,7 @@ export const unhandledRejection = async (error: Error, promise: Promise<any>) =>
     }
 
     fs.appendFileSync(
-        path.join(__dirname, '../../logs/unhandledRejection.txt'),
+        path.join(__dirname, '../../logs/unhandledRejection.log'),
         `
      time:                   ${new Date()}
      unhandledRejection:     ${JSON.stringify(promise)}

--- a/src/resources/consumer/consumer.memory.repository.ts
+++ b/src/resources/consumer/consumer.memory.repository.ts
@@ -2,7 +2,7 @@ import { IBaseConsumer, IConsumer } from './consumer.interface';
 
 import Consumer from './consumer.model';
 
-const CONSUMERS: IConsumer[] = [];
+const CONSUMERS: IConsumer[] = [new Consumer()];
 
 const getAll = async (): Promise<IConsumer[]> => CONSUMERS;
 

--- a/src/resources/consumer/consumer.router.ts
+++ b/src/resources/consumer/consumer.router.ts
@@ -1,17 +1,17 @@
 import { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
-
+import asyncHandler from 'express-async-handler';
 import Consumer from './consumer.model';
 import Order from '../order/order.model';
-
 import consumersService from './consumer.service';
+
 import catchErrors from '../../common/catchErrors';
 
 const router = Router();
 
 router.route('/').get(
-  catchErrors(async (_req: Request, res: Response) => {
+  asyncHandler(async (_req: Request, res: Response) => {
     const consumers = await consumersService.getAll();
 
     res.json(consumers.map(Consumer.toResponse));
@@ -19,7 +19,7 @@ router.route('/').get(
 );
 
 router.route('/:id').get(
-  catchErrors(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const {
       id
     } = req.params;
@@ -36,11 +36,13 @@ router.route('/:id').get(
           msg: 'Consumer not found'
         });
     }
+    throw new Error("error");
+    // Promise.reject(Error("Error consumer"));
   })
 );
 
 router.route('/:id/orders').get(
-  catchErrors(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const {
       id
     } = req.params;
@@ -61,7 +63,7 @@ router.route('/:id/orders').get(
 );
 
 router.route('/').post(
-  catchErrors(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const {
       lastName,
       firstName,
@@ -90,7 +92,7 @@ router.route('/').post(
 );
 
 router.route('/:id').put(
-  catchErrors(async (req: Request, res: Response) => {
+  asyncHandler(async (req: Request, res: Response) => {
     const {
       id
     } = req.params;

--- a/src/resources/order/order.memory.repository.ts
+++ b/src/resources/order/order.memory.repository.ts
@@ -3,7 +3,7 @@ import Order from './order.model';
 import productsRepo from '../product/product.memory.repository';
 
 
-const ORDERS: IOrder[] = [];
+const ORDERS: IOrder[] = [new Order()];
 
 const getAll = async (): Promise<IOrder[]> => ORDERS;
 

--- a/src/resources/order/order.router.ts
+++ b/src/resources/order/order.router.ts
@@ -1,17 +1,17 @@
 import { Request, Response, Router } from 'express';
 import { StatusCodes } from 'http-status-codes';
 
-
+import asyncHandler from 'express-async-handler';
 import Product from '../product/product.model';
 import Order from './order.model';
-
 import ordersService from './order.service';
+
 import catchErrors from '../../common/catchErrors';
 
 const router = Router();
 
 router.route('/').get(
-    catchErrors(async (_req: Request, res: Response) => {
+    asyncHandler(async (_req: Request, res: Response) => {
         const orders = await ordersService.getAll();
 
         res.json(orders.map(Order.toResponse));
@@ -19,7 +19,7 @@ router.route('/').get(
 );
 
 router.route('/:id').get(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             id
         } = req.params;
@@ -40,7 +40,7 @@ router.route('/:id').get(
 );
 
 router.route('/:id/products').get(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             id
         } = req.params;
@@ -61,7 +61,7 @@ router.route('/:id/products').get(
 );
 
 router.route('/').post(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             consumerId,
             date,
@@ -88,7 +88,7 @@ router.route('/').post(
 );
 
 router.route('/:id').put(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             id
         } = req.params;

--- a/src/resources/product/product.memory.repository.ts
+++ b/src/resources/product/product.memory.repository.ts
@@ -1,7 +1,7 @@
 import { IProduct, IBaseProduct } from './product.interface';
 import Product from './product.model';
 
-const PRODUCTS: IProduct[] = []
+const PRODUCTS: IProduct[] = [new Product()]
 
 const getAll = async (): Promise<IProduct[]> => PRODUCTS;
 

--- a/src/resources/product/product.router.ts
+++ b/src/resources/product/product.router.ts
@@ -1,16 +1,16 @@
 import { StatusCodes } from 'http-status-codes';
 import { Request, Response, Router } from 'express';
 
-
+import asyncHandler from 'express-async-handler';
 import Product from './product.model';
-
 import productsService from './product.service';
+
 import catchErrors from '../../common/catchErrors';
 
 const router = Router();
 
 router.route('/').get(
-    catchErrors(async (_req: Request, res: Response) => {
+    asyncHandler(async (_req: Request, res: Response) => {
         const products = await productsService.getAll();
 
         res.json(products.map(Product.toResponse));
@@ -18,7 +18,7 @@ router.route('/').get(
 );
 
 router.route('/:id').get(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             id
         } = req.params;
@@ -35,11 +35,12 @@ router.route('/:id').get(
                     msg: 'Product not found'
                 });
         }
+        throw new Error("errror");
     })
 );
 
 router.route('/').post(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             orderId,
             title,
@@ -67,7 +68,7 @@ router.route('/').post(
 );
 
 router.route('/:id').put(
-    catchErrors(async (req: Request, res: Response) => {
+    asyncHandler(async (req: Request, res: Response) => {
         const {
             id
         } = req.params;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,7 +1,13 @@
 import config from './common/config';
 import app from './app';
 
+import { unhandledRejection, uncaughtException } from './middlewares';
+
 const { PORT } = config;
 
 app.listen(PORT, () => console.log(`App is running on http://localhost:${PORT}`)
 );
+
+process.on('uncaughtException', uncaughtException);
+
+process.on('unhandledRejection', unhandledRejection);


### PR DESCRIPTION
# Лабораторная работа No4. Logging & Error Handling

- [x] 1. Создайте ветку task4/logging-error-handling.
- [x] 2. Добавьте middleware, которое будет регистрировать входящие запросы к
сервису (как минимум, url, query parameters, body) и status code ответа.
#### Для проверки используем Postman
#### На Image1 указаны - query-параметры; на Image2 вручную в формате JSON указан - body; на Image3 показан файл с логом после отправки запроса.
#### Image1: 

<img width="1190" alt="Снимок экрана 2021-12-28 в 20 50 16" src="https://user-images.githubusercontent.com/75899047/147594394-d3d6c7a8-50e2-4cf6-ac48-dae93a21e31e.png">

#### Image2: 

<img width="1183" alt="Снимок экрана 2021-12-28 в 20 50 23" src="https://user-images.githubusercontent.com/75899047/147594388-a15cfae4-19cb-405f-b882-0cd17055b696.png">

#### Image3: 

<img width="683" alt="Снимок экрана 2021-12-28 в 20 50 40" src="https://user-images.githubusercontent.com/75899047/147594396-308dff6b-a2fe-4dc1-be80-d86fd37c5f06.png">

- [x] 3. Добавьте middleware, которое будет регистрировать все необработанные
errors и возвращать стандартное сообщение с кодом HTTP 500 (Internal
Server Error).

#### Для проверки используем Postman. Для вызова этой ошибки вручную прописываем в consumer.router `throw new Error("error");` как показано Image4.

#### На Image1 отправляем запрос для поиска Consumer c id = asdf, выдает сообщение -> 
`{
 "code": "CONSUMER_NOT_FOUND",
 "msg": "Consumer not found"
}`
#### На Image2 показано, что middleware, который регистрирует входящие запросы  зарегистрировала этот запрос
#### На Image3  изображена запись из лог файла с этой ошибкой.


#### Image1:

<img width="1177" alt="Снимок экрана 2021-12-28 в 21 32 07" src="https://user-images.githubusercontent.com/75899047/147596291-e4a9b6ac-359c-41ff-89e6-1b3fb2ebe6b2.png">

#### Image2:

<img width="473" alt="Снимок экрана 2021-12-28 в 20 53 55" src="https://user-images.githubusercontent.com/75899047/147595639-61a3dfee-a20b-4e08-8562-aa12ad50e8f3.png">

#### Image3:

<img width="480" alt="Снимок экрана 2021-12-28 в 20 54 01" src="https://user-images.githubusercontent.com/75899047/147595517-3148c047-f270-418c-a42f-d123f3086944.png">

#### Image4:

<img width="460" alt="Снимок экрана 2021-12-28 в 20 54 12" src="https://user-images.githubusercontent.com/75899047/147595529-6af60a82-e2bd-447a-8e16-76dd38cb3eef.png">

- [x] 4. Добавить обработку и логирование ошибок на событие uncaughtException.


#### На картинке показано что при попытке запуска сервера во второй раз(на другом терминале) выдаст ошибку `listen EADDRINUSE: address already in use :::4000`

<img width="1085" alt="Снимок экрана 2021-12-28 в 20 56 55" src="https://user-images.githubusercontent.com/75899047/147597605-750d3281-402e-4113-9e00-b9d97d5f3cf9.png">

- [x] 5. Добавить обработку и логирование ошибок на событие
unhandledRejection.

#### Для проверки ошибки unhandledRejection можно вписать `Promise.reject((Error("Error consumer"));`

<img width="873" alt="Снимок экрана 2021-12-28 в 20 59 56" src="https://user-images.githubusercontent.com/75899047/147597626-2e582eb5-3911-4efd-9c68-c22a21beb334.png">

- [x] 6. Процесс логирования осуществляется единственным модулем (т.е. код,
осуществляющий логирование, находится в одном модуле, при этом этот
модуль может использоваться внутри других модулей).

- [x] 7. Логи записываются в файл.
- [x] 8. Логи ошибок записываются в отдельный файл (либо только в него, либо в
дополнение к записи в общий файл)
- [ ] 9. Для логирования можно использовать любую стороннюю библиотеку
(например, winston и morgan).